### PR TITLE
Discontinue lodash pick

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 import stylelint from 'stylelint';
 // eslint-disable-next-line import/no-unresolved -- https://github.com/import-js/eslint-plugin-import/issues/2703
 import doiuse from 'doiuse';
-import pick from 'lodash.pick';
 import { Result } from 'postcss';
 
 /**
@@ -80,16 +79,22 @@ function ruleFunction(on, options) {
       return;
     }
 
-    const ignorePartialSupport = options ? options.ignorePartialSupport : false;
-    const doiuseOptions = pick(options, Object.keys(optionsSchema));
-    const doiuseResult = new Result();
-
     const usedFeatures = {};
+    const doiuseResult = new Result();
+    const doiuseOptions = {};
+
+    if (options) {
+      Object.keys(optionsSchema).forEach((optionsKey) => {
+        doiuseOptions[optionsKey] = options[optionsKey];
+      });
+    }
 
     doiuseOptions.onFeatureUsage = (info) => {
       // Use the node as key to store feature information
       usedFeatures[info.usage] = info.featureData;
     };
+
+    const { ignorePartialSupport } = doiuseOptions;
 
     doiuse(doiuseOptions).postcss(root, doiuseResult);
     doiuseResult.warnings().forEach((doiuseWarning) => {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "doiuse": "^6.0.2",
-    "lodash.pick": "^4.4.0",
     "postcss": "^8.4.32"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves https://github.com/RJWadley/stylelint-no-unsupported-browser-features/pull/296#issuecomment-1909754353

This commit removes the use of lodash.pick since lodash.pick is not maintained and including lodash just for this instance seems like an overkill.